### PR TITLE
Event Versioning and Rulesets Data

### DIFF
--- a/lib/classes/BaseCreative.js
+++ b/lib/classes/BaseCreative.js
@@ -278,7 +278,7 @@ export default class {
    * @returns {*}
    */
   dataGetMeta() {
-    return this._dataReceived.metaDataReceived.data;
+    return _get(this._dataReceived.metaDataReceived, 'data');
   }
 
   /**
@@ -287,7 +287,7 @@ export default class {
    * @returns {*}
    */
   dataGetCampaign() {
-    return this._dataReceived.campaignDataReceived.data;
+    return _get(this._dataReceived.campaignDataReceived, 'data');
   }
 
   /**
@@ -296,7 +296,7 @@ export default class {
    * @returns []
    */
   dataGetItems() {
-    return this._dataReceived.dataReceived.data;
+    return _get(this._dataReceived.dataReceived, 'data');
   }
 
   /**
@@ -305,7 +305,7 @@ export default class {
    * @returns []
    */
   dataGetRulesets() {
-    return this._dataReceived.rulesetsDataReceived.data;
+    return _get(this._dataReceived.rulesetsDataReceived, 'data');
   }
 
   /**

--- a/lib/classes/BaseCreative.js
+++ b/lib/classes/BaseCreative.js
@@ -278,7 +278,7 @@ export default class {
    * @returns {*}
    */
   dataGetMeta() {
-    return _get(this._dataReceived.metaDataReceived, 'data');
+    return _get(this._dataReceived.metaDataReceived, 'data', null);
   }
 
   /**
@@ -287,7 +287,7 @@ export default class {
    * @returns {*}
    */
   dataGetCampaign() {
-    return _get(this._dataReceived.campaignDataReceived, 'data');
+    return _get(this._dataReceived.campaignDataReceived, 'data', null);
   }
 
   /**
@@ -296,7 +296,7 @@ export default class {
    * @returns []
    */
   dataGetItems() {
-    return _get(this._dataReceived.dataReceived, 'data');
+    return _get(this._dataReceived.dataReceived, 'data', null);
   }
 
   /**
@@ -305,7 +305,7 @@ export default class {
    * @returns []
    */
   dataGetRulesets() {
-    return _get(this._dataReceived.rulesetsDataReceived, 'data');
+    return _get(this._dataReceived.rulesetsDataReceived, 'data', null);
   }
 
   /**

--- a/lib/classes/BaseCreative.js
+++ b/lib/classes/BaseCreative.js
@@ -12,8 +12,9 @@ import _head from 'lodash/head';
 import _merge from 'lodash/merge';
 import _assign from 'lodash/assign';
 import _filter from 'lodash/filter';
-import _upperFirst from 'lodash/upperFirst';
 import emojiRegex from 'emoji-regex';
+import _upperFirst from 'lodash/upperFirst';
+import version, {unversionEvent} from '../version';
 
 export default class {
 
@@ -32,11 +33,18 @@ export default class {
 
     this.fallback = this.elById('fallback');
 
-    this._dataEvents = ['metaData', 'campaignData', 'data'];
+    this._dataEvents = ['rulesetsData', 'metaData', 'campaignData', 'data'];
     this._dataReceived = {};
 
     this._assetList = this.creativeAssets();
     this._assetLoadCount = 0;
+  }
+
+  /**
+   * Return Player JS Version.
+   */
+  getVersion() {
+    return version;
   }
 
   /**
@@ -45,6 +53,8 @@ export default class {
    * @param data
    */
   receiveData(event, data) {
+
+    event = unversionEvent(event);
 
     // Attempt to call handler
     this._call(event + 'Handler', [data]);
@@ -268,7 +278,7 @@ export default class {
    * @returns {*}
    */
   dataGetMeta() {
-    return this._dataReceived.metaDataReceived;
+    return this._dataReceived.metaDataReceived.data;
   }
 
   /**
@@ -277,7 +287,7 @@ export default class {
    * @returns {*}
    */
   dataGetCampaign() {
-    return this._dataReceived.campaignDataReceived;
+    return this._dataReceived.campaignDataReceived.data;
   }
 
   /**
@@ -286,7 +296,16 @@ export default class {
    * @returns []
    */
   dataGetItems() {
-    return this._dataReceived.dataReceived;
+    return this._dataReceived.dataReceived.data;
+  }
+
+  /**
+   * Returns rulesets
+   *
+   * @returns []
+   */
+  dataGetRulesets() {
+    return this._dataReceived.rulesetsDataReceived.data;
   }
 
   /**

--- a/lib/classes/BaseCreative.js
+++ b/lib/classes/BaseCreative.js
@@ -33,7 +33,7 @@ export default class {
 
     this.fallback = this.elById('fallback');
 
-    this._dataEvents = ['rulesetsData', 'metaData', 'campaignData', 'data'];
+    this._dataEvents = ['metaData', 'campaignData', 'data', 'rulesetsData'];
     this._dataReceived = {};
 
     this._assetList = this.creativeAssets();

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,4 +1,4 @@
-import {versionEvent} from 'version';
+import {versionEvent} from './version';
 
 export default (meta, campaign, dataItems, rulesets) => {
   window.postMessage({event: versionEvent('metaDataReceived'), data: meta}, "*");

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,6 +1,9 @@
-export default (meta, campaign, dataItems) => {
-  window.postMessage({event: "metaDataReceived", data: meta}, "*");
-  window.postMessage({event: "campaignDataReceived", data: campaign}, "*");
-  window.postMessage({event: "dataReceived", data: dataItems}, "*");
-  window.postMessage({event: "start", data: null}, "*");
+import {versionEvent} from 'version';
+
+export default (meta, campaign, dataItems, rulesets) => {
+  window.postMessage({event: versionEvent('metaDataReceived'), data: meta}, "*");
+  window.postMessage({event: versionEvent('campaignDataReceived'), data: campaign}, "*");
+  window.postMessage({event: versionEvent('dataReceived'), data: dataItems}, "*");
+  window.postMessage({event: versionEvent('rulesetsDataReceived'), data: rulesets}, "*");
+  window.postMessage({event: 'start', data: null}, "*");
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -10,7 +10,6 @@ export default version;
  * @param event
  * @returns {string}
  */
-
 export const versionEvent = event => {
   return `v${version}.${event}`;
 };

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,26 @@
+/**
+ * Player JS API Version.
+ */
+const version = 1;
+export default version;
+
+/**
+ * Return versioned event string.
+ *
+ * @param event
+ * @returns {string}
+ */
+
+export const versionEvent = event => {
+  return `v${version}.${event}`;
+};
+
+/**
+ * Strip versioning from event string.
+ *
+ * @param event
+ * @returns {string}
+ */
+export const unversionEvent = event => {
+  return event.replace(`v${version}.`, '');
+};

--- a/src/events.js
+++ b/src/events.js
@@ -2,5 +2,6 @@ import events from 'smartcontent-cdk/lib/events';
 import meta from './data/meta';
 import campaign from './data/campaign';
 import dataItems from './data/data';
+import rulesets from './data/rulesets';
 
-events(meta, campaign, dataItems);
+events(meta, campaign, dataItems, rulesets);

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@
  * Browser entry point
  */
 import Creative from './Creative.js';
+import {versionEvent} from 'smartcontent-cdk/lib/version';
 
 /**
  * Initialise Creative and Listen for events.
@@ -12,13 +13,14 @@ import Creative from './Creative.js';
  */
 document.addEventListener('DOMContentLoaded', () => {
 
-  let creative = new Creative(window);
+  const creative = new Creative(window);
 
   window.addEventListener('message', (event) => {
     switch (event.data.event) {
-      case 'metaDataReceived':
-      case 'dataReceived':
-      case 'campaignDataReceived':
+      case versionEvent('metaDataReceived'):
+      case versionEvent('dataReceived'):
+      case versionEvent('campaignDataReceived'):
+      case versionEvent('rulesetsDataReceived'):
         creative.receiveData(event.data.event, event.data.data);
         break;
       case 'start':


### PR DESCRIPTION
This PR introduces event versioning to work with the respective player JS changes. This is a breaking change and once merged will be tagged as a new minor version.

This PR also adds the ruleset data event and helper to the `BaseCreative` class.