### PR TITLE
Rollup fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-template": "^4.0.0",
     "jquery": "^3.1.0",
     "laravel-elixir": "^6.0.0-10",
-    "laravel-elixir-rollup-official": "^1.0.4",
+    "laravel-elixir-rollup-official": "dynamicdo/Laravel-Elixir-Rollup#rollupfixes",
     "laravel-elixir-webpack-official": "^1.0.8",
     "lodash": "^4.14.0",
     "moment": "^2.15.0",


### PR DESCRIPTION
Uses fork of `laravel-elixir-rollup-official` to include rollupfixes